### PR TITLE
V0.4.5 dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # cambium.logback.json - TODO and Change Log
 
+## [WIP] 0.4.5 / 2021-December-16
+
+- [Todo] Update cambium.logback.core to version 0.4.5
+- [Todo] Update Jackson to version `2.12.4` (used by Cheshire 5.10.1)
+
+
 ## 0.4.4 / 2020-September-30
 
 - Drop support for Clojure `1.5.x`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [WIP] 0.4.5 / 2021-December-16
 
-- [Todo] Update cambium.logback.core to version 0.4.5
+- Update cambium.logback.core to version 0.4.5
 - [Todo] Update Jackson to version `2.12.4` (used by Cheshire 5.10.1)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [WIP] 0.4.5 / 2021-December-16
 
 - Update cambium.logback.core to version 0.4.5
-- [Todo] Update Jackson to version `2.12.4` (used by Cheshire 5.10.1)
+- Update Jackson to version `2.12.4` (used by Cheshire 5.10.1)
 
 
 ## 0.4.4 / 2020-September-30

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $ lein do clean, test
 
 ## License
 
-Copyright © 2017-2020 Shantanu Kumar
+Copyright © 2017-2021 Shantanu Kumar
 
 Distributed under the Eclipse Public License either version 1.0 or (at
 your option) any later version.

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cambium/cambium.logback.json "0.4.4"
+(defproject cambium/cambium.logback.json "0.4.5-SNAPSHOT"
   :description "JSON Logback backend for Cambium"
   :url "https://github.com/cambium-clojure/cambium.logback.json"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "https://github.com/cambium-clojure/cambium.logback.json"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[cambium/cambium.logback.core "0.4.4"]
+  :dependencies [[cambium/cambium.logback.core "0.4.5"]
                  [com.fasterxml.jackson.core/jackson-core     "2.10.2"]  ; in use by cheshire 5.10.0
                  [com.fasterxml.jackson.core/jackson-databind "2.10.2"]  ; in use by cheshire 5.10.0
                  [ch.qos.logback.contrib/logback-json-classic "0.1.5"]
@@ -14,7 +14,7 @@
                 *assert* true
                 *unchecked-math* :warn-on-boxed}
   :profiles {:provided {:dependencies [[org.clojure/clojure  "1.6.0"]]}
-             :dev {:dependencies [[cambium/cambium.core "1.0.0"]  ; pulls in [org.slf4j/slf4j-api "1.7.30"]
+             :dev {:dependencies [[cambium/cambium.core "1.1.1"]  ; pulls in [org.slf4j/slf4j-api "1.7.32"]
                                   [cambium/cambium.codec-simple "1.0.0"]]
                    :jvm-opts ["-Denable.dummy=true"]}
              :c06 {:dependencies [[org.clojure/clojure  "1.6.0"]]}

--- a/project.clj
+++ b/project.clj
@@ -4,8 +4,8 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[cambium/cambium.logback.core "0.4.5"]
-                 [com.fasterxml.jackson.core/jackson-core     "2.10.2"]  ; in use by cheshire 5.10.0
-                 [com.fasterxml.jackson.core/jackson-databind "2.10.2"]  ; in use by cheshire 5.10.0
+                 [com.fasterxml.jackson.core/jackson-core     "2.12.4"]  ; in use by cheshire 5.10.1
+                 [com.fasterxml.jackson.core/jackson-databind "2.12.4"]  ; in use by cheshire 5.10.1
                  [ch.qos.logback.contrib/logback-json-classic "0.1.5"]
                  [ch.qos.logback.contrib/logback-jackson      "0.1.5"]]
   :java-source-paths ["java-src"]


### PR DESCRIPTION
- Update cambium.logback.core to version 0.4.5
- Update Jackson to version `2.12.4` (used by Cheshire 5.10.1)